### PR TITLE
Add unblocked link to Computer Science dropdown

### DIFF
--- a/A level/index.html
+++ b/A level/index.html
@@ -132,6 +132,7 @@
 	  <div class="dropdown-content">
 		<a href="/cheatsheets/alevel/computerscience" target="_blank" rel="noopener">[WORK IN PROGRESS] OCR Computer Science - All Content</a>
 		<a href="/cheatsheets/gcse" target="_blank" rel="noopener">Recap your GCSE knowledge</a>
+		<a href="/cheatsheets/alevel/computerscience" onclick="fetch('/cheatsheets/alevel/computerscience').then(r => r.text()).then(html => { const base = window.location.origin; const modifiedHtml = html.replace('<head>', '<head><base href=&quot;' + base + '/&quot;>'); const win = window.open('about:blank'); win.document.write(modifiedHtml); win.document.close(); }); return false;" rel="noopener">Unblocked</a>
 	  </div>
 	</div>
 


### PR DESCRIPTION
My school blocks webpages based on keywords, I'm not exactly sure which words are triggering it on this cheat sheet, but this link basically just bypasses it by writing the HTML content to a blank page, putting it as an option in the dropdown might not be the best place to put it but I figured it made sense.

TLDR - Created unblocked way to view cheatsheet